### PR TITLE
Add Security Headers and security.txt

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,77 @@
 /** @type {import('next').NextConfig} */
+const isDev = process.env.NODE_ENV !== 'production';
+
+const contentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: blob: https:;
+  font-src 'self' data: https:;
+  connect-src 'self' https:;
+  frame-src 'self' https://cal.com https://*.cal.com;
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'self';
+  manifest-src 'self';
+  worker-src 'self' blob:;
+  upgrade-insecure-requests;
+`;
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy.replaceAll(/\s{2,}/g, ' ').trim(),
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'X-XSS-Protection',
+    value: '1; mode=block',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), payment=(self)',
+  },
+  {
+    key: 'Cross-Origin-Opener-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'Cross-Origin-Resource-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'off',
+  },
+];
+
 const nextConfig = {
   output: 'standalone',
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:pp.namias@gmail.com
+Contact: https://namias.tech
+Expires: 2027-04-11T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://namias.tech/.well-known/security.txt
+Policy: https://github.com/PP-Namias/Portfolio/blob/main/SECURITY.md

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:pp.namias@gmail.com
+Contact: https://namias.tech
+Expires: 2027-04-11T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://namias.tech/.well-known/security.txt
+Policy: https://github.com/PP-Namias/Portfolio/blob/main/SECURITY.md


### PR DESCRIPTION
https://web-check.xyz/check/https%3A%2F%2Fnamias.tech%2F

<img width="1280" height="1024" alt="image" src="https://github.com/user-attachments/assets/4134a8fc-510e-4225-9e31-3c692741706f" />


Implements missing HTTP/web security controls identified in the latest Web Check audit for `namias.tech`.


The audit reported missing or incomplete security controls, including:

- `security.txt` not found
- HSTS not including all subdomains
- Missing `Content-Security-Policy`
- Missing `X-Content-Type-Options`
- Missing `X-Frame-Options`
- Missing `X-XSS-Protection`

Security audit mapping (Before → After)

- `Security.txt Present`: ❌ → ✅
- `HSTS includeSubDomains`: ❌ → ✅
- `Content Security Policy`: ❌ → ✅
- `X-Content-Type-Options`: ❌ → ✅
- `X-Frame-Options`: ❌ → ✅
- `X-XSS-Protection`: ❌ → ✅
