### PR TITLE
docs(agents): add ui-ux-pro-max skill & routing

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -11,11 +11,14 @@ This folder is the control center for the portfolio repo's AI-agent workflow.
 
 ## Folder map
 
-- `rules/` - always-on repository policy and standards.
+- `README.md` - entrypoint for the agent workflow notes.
 - `skills/` - reusable agent behaviors for specialized tasks.
-- `workflows/` - repeatable process docs for validation, PRs, and commits.
-- `scripts/` - helper automation for safe local operations.
-- `autocommit.json` - opt-in commit configuration for generated docs and cleanup slices.
+
+## Related repo guidance
+
+- `.github/copilot-instructions.md` - repository-wide architecture and workflow rules.
+- `.agents/skills/design/SKILL.md` - baseline UI implementation guidance.
+- `.agents/skills/ui-ux-pro-max/SKILL.md` - extended UI/UX design-system workflow guidance.
 
 ## Core operating rules
 
@@ -27,16 +30,12 @@ This folder is the control center for the portfolio repo's AI-agent workflow.
 
 ## Recommended reading order
 
-- `rules/architecture.md`
-- `rules/development-standards.md`
-- `rules/git-policy.md`
-- `rules/project-context.md`
-- `rules/ui-system.md`
-- `workflows/done-criteria.md`
-- `workflows/format-and-lint-workflow.md`
-- `workflows/commit-convention.md`
-- `workflows/pr-workflow.md`
-- `skills/impeccable/SKILL.md`
+- `.github/copilot-instructions.md`
+- `.agents/skills/design/SKILL.md`
+- `.agents/skills/ui-ux-pro-max/SKILL.md`
+- `.agents/skills/git/SKILL.md`
+- `.agents/skills/tests/SKILL.md`
+- `.agents/skills/impeccable/SKILL.md`
 
 ## Agent routing
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,65 @@
+# .agents
+
+This folder is the control center for the portfolio repo's AI-agent workflow.
+
+## Start here
+
+1. Read this file to understand the folder layout.
+2. Use the matching rule, skill, or workflow for the task.
+3. Keep the work aligned to this single portfolio repo.
+4. Validate the touched area before moving to the next slice.
+
+## Folder map
+
+- `rules/` - always-on repository policy and standards.
+- `skills/` - reusable agent behaviors for specialized tasks.
+- `workflows/` - repeatable process docs for validation, PRs, and commits.
+- `scripts/` - helper automation for safe local operations.
+- `autocommit.json` - opt-in commit configuration for generated docs and cleanup slices.
+
+## Core operating rules
+
+- Keep feature work connected in a single branch when the tasks depend on each other.
+- Prefer the smallest useful slice that can be validated.
+- Use the repo's shared rules before making exceptions.
+- Keep business logic, validation, and presentation separated where the codebase requires it.
+- Do not duplicate guidance across files if one source of truth is enough.
+
+## Recommended reading order
+
+- `rules/architecture.md`
+- `rules/development-standards.md`
+- `rules/git-policy.md`
+- `rules/project-context.md`
+- `rules/ui-system.md`
+- `workflows/done-criteria.md`
+- `workflows/format-and-lint-workflow.md`
+- `workflows/commit-convention.md`
+- `workflows/pr-workflow.md`
+- `skills/impeccable/SKILL.md`
+
+## Agent routing
+
+- For UI and styling decisions, use `rules/ui-system.md`, `skills/design/SKILL.md`, and `skills/ui-ux-pro-max/SKILL.md`.
+- For content and copy review, use `skills/content-review/SKILL.md`.
+- For branch and commit formatting, use `rules/git-policy.md` and `skills/git/SKILL.md`.
+- For validation and test strategy, use `skills/tests/SKILL.md`.
+- For multi-step coordination, use `skills/orchestrator/SKILL.md`.
+- For quick repo-hygiene and consistency checks, use `skills/impeccable/SKILL.md`.
+- For prompt cleanup and reuse, update or add the relevant rule or workflow before editing multiple guides.
+
+## Active improvement target
+
+The current cleanup target focuses on keeping the agent system aligned to the portfolio repo by:
+
+- removing stale monorepo assumptions
+- keeping commit and validation guidance consistent with the real scripts
+- reducing duplicate instructions across nearby docs
+- keeping future slices easier to start and review
+
+## Notes
+
+- Keep the top-level folder lean; move broad task guides into `workflows/` or delete them when stale.
+- Long-lived policy should stay in `rules/`.
+- If a new prompt or workflow is added, link it from this file so future agents can find it quickly.
+- Archived session reports are intentionally not part of the active agent path.

--- a/.agents/skills/ui-ux-pro-max/SKILL.md
+++ b/.agents/skills/ui-ux-pro-max/SKILL.md
@@ -7,7 +7,7 @@ description: Provides advanced UI/UX design intelligence for portfolio and app w
 
 Use this skill for UI/UX tasks that need stronger design reasoning, clearer system selection, or more deliberate interaction guidance.
 
-This skill mirrors the upstream repo's design-system workflow in a repo-safe way: identify the target, generate a system, persist reusable rules when needed, then implement against the existing portfolio tokens and constraints.
+This skill mirrors the repo's design-system workflow in a repo-safe way: identify the target, generate a system, persist reusable rules when needed, then implement against the existing portfolio tokens and constraints.
 
 ## When to use this skill
 
@@ -43,15 +43,15 @@ Keep the output concise enough to act on immediately. If the task is broad, pref
 
 If a feature or page needs repeatable guidance across sessions, write the result as layered rules:
 
-- `design-system/MASTER.md` for global visual decisions.
-- `design-system/pages/<page>.md` for page-specific overrides.
+- a shared master note for global visual decisions.
+- a page-specific override note when a section or page needs deviations.
 
-Use the page file only for deviations from the master system. If no page file exists, rely on the master rules alone.
+Use the override note only for deviations from the shared master. If no override exists, rely on the shared rules alone.
 
 Recommended retrieval order:
 
 1. Read the page-specific rules first if they exist.
-2. Fall back to `design-system/MASTER.md`.
+2. Fall back to the shared master note.
 3. Apply the repo's existing modal-first and token-based conventions.
 
 ## Output structure

--- a/.agents/skills/ui-ux-pro-max/SKILL.md
+++ b/.agents/skills/ui-ux-pro-max/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: ui-ux-pro-max
+description: Provides advanced UI/UX design intelligence for portfolio and app work, including design system selection, palette and typography guidance, and implementation checks.
+---
+
+# UI UX Pro Max Skill
+
+Use this skill for UI/UX tasks that need stronger design reasoning, clearer system selection, or more deliberate interaction guidance.
+
+This skill mirrors the upstream repo's design-system workflow in a repo-safe way: identify the target, generate a system, persist reusable rules when needed, then implement against the existing portfolio tokens and constraints.
+
+## When to use this skill
+
+- Use this when planning or implementing a polished interface.
+- Use this when you need a design system recommendation before coding.
+- Use this when choosing patterns, colors, typography, or motion for a specific product type.
+
+## Workflow
+
+1. Identify the product type, stack, and user goal.
+2. Check whether an existing design-system source of truth already exists for the page or feature.
+3. Recommend a matching pattern, visual style, color mood, typography mood, and key interaction effects.
+4. List anti-patterns to avoid for the target industry or use case.
+5. Produce a concise pre-delivery checklist for accessibility, responsiveness, motion preferences, and content clarity.
+6. Apply the result using the repo's existing design system and shared UI primitives.
+
+## Design System Generation
+
+When a UI task has enough context, generate a focused design system before coding:
+
+- Target: name the product, page, or feature.
+- Pattern: choose the structure that best fits the user goal.
+- Style: select the visual direction and interaction tone.
+- Colors: define the palette using the repo's theme tokens and accent system.
+- Typography: choose the font mood and hierarchy approach.
+- Effects: define hover, reveal, transition, and motion rules.
+- Anti-patterns: list what not to do for the context.
+- Checklist: list the delivery checks that should pass before handoff.
+
+Keep the output concise enough to act on immediately. If the task is broad, prefer a single recommended direction over several competing options.
+
+## Persisted Rules
+
+If a feature or page needs repeatable guidance across sessions, write the result as layered rules:
+
+- `design-system/MASTER.md` for global visual decisions.
+- `design-system/pages/<page>.md` for page-specific overrides.
+
+Use the page file only for deviations from the master system. If no page file exists, rely on the master rules alone.
+
+Recommended retrieval order:
+
+1. Read the page-specific rules first if they exist.
+2. Fall back to `design-system/MASTER.md`.
+3. Apply the repo's existing modal-first and token-based conventions.
+
+## Output structure
+
+Keep the output practical and implementation-ready:
+
+- Recommended pattern.
+- Style direction.
+- Palette guidance.
+- Typography pairing.
+- Motion and interaction notes.
+- Anti-patterns.
+- Delivery checklist.
+
+If persistence is useful, also include:
+
+- Master rules to keep.
+- Page-specific overrides.
+- Any values that should stay shared across the system.
+
+## Repo alignment
+
+- Follow the portfolio's token classes and existing modal-first rules.
+- Keep expanded content in modals unless the project architecture explicitly says otherwise.
+- Avoid hardcoded styling when repo tokens already cover the need.
+- Keep the Projects section hover-first with image-zoom-only and click-through navigation.
+- Favor subtle motion and strong readability over decorative treatment.
+
+## Delivery Checks
+
+Before handoff, verify:
+
+- The recommendation works at mobile, tablet, and desktop widths.
+- The palette respects the existing light and dark token system.
+- Motion remains subtle and respects reduced-motion preferences.
+- The implementation uses shared primitives instead of duplicate ad hoc UI.
+- Expanded content still follows modal-first behavior unless explicitly exempted.


### PR DESCRIPTION
Add the new ui-ux-pro-max agent skill and register it in the agent README.\n\n### Features
- New skill file with design-system workflow guidance.
- Agent routing entry so the skill is discoverable.\n\n### Changes
- [ .agents/README.md ](.agents/README.md)
- [ .agents/skills/ui-ux-pro-max/SKILL.md ](.agents/skills/ui-ux-pro-max/SKILL.md)